### PR TITLE
Add FindLibArchive.cmake

### DIFF
--- a/moor/FindLibArchive.cmake
+++ b/moor/FindLibArchive.cmake
@@ -1,0 +1,32 @@
+# Author: Alexander Böhn / http://github.com/fish2000 / © 2015.04
+# FindLibArchive.cmake
+
+FIND_PATH(LibArchive_ROOT_DIR
+    NAMES include/archive.h include/archive_entry.h
+    PATH_SUFFIXES libarchive/include)
+
+FIND_PATH(LibArchive_LIBRARIES
+    NAMES libarchive
+    HINTS ${LibArchive_ROOT_DIR}/lib
+    PATH_SUFFIXES libarchive/lib)
+
+FIND_PATH(LibArchive_INCLUDE_DIR
+    NAMES archive.h archive_entry.h
+    HINTS ${LibArchive_ROOT_DIR}/include
+    PATH_SUFFIXES libarchive/include)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    LibArchive DEFAULT_MSG
+    LibArchive_LIBRARIES
+    LibArchive_INCLUDE_DIR)
+
+SET(LibArchive_LIBRARY      LibArchive_LIBRARIES            PARENT_SCOPE)
+SET(LibArchive_INCLUDE_DIRS LibArchive_INCLUDE_DIR          PARENT_SCOPE)
+
+MARK_AS_ADVANCED(
+    LibArchive_ROOT_DIR
+    LibArchive_LIBRARY
+    LibArchive_LIBRARIES
+    LibArchive_INCLUDE_DIR
+    LibArchive_INCLUDE_DIRS)


### PR DESCRIPTION
This was necessary in order to build moor on my system (OS X 10.10) – thought it might be useful to others. 

I had to modify `CMakeLists.txt` like this as well:

```
SET(ADDITIONAL_LIBS "")
SET(LibArchive_INCLUDE_DIR /usr/include)

SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
FIND_PACKAGE(LibArchive REQUIRED)
```

… but those would be largely dependent on the system, _qua_ the current build system, n’est ce pas? Indeed. 

In any case thanks for wrapping libarchive in c++

-fish
